### PR TITLE
fix(docs): update pay statement type to regular_payroll

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -740,7 +740,7 @@ paths:
                                     type: string
                                     description: The type of the payment associated with the pay statement.
                                     enum:
-                                      - regular
+                                      - regular_payroll
                                       - off_cycle_payroll
                                       - one_time_payment
                                     nullable: true


### PR DESCRIPTION
https://tryfinch.halp.com/tickets/1631

I searched for "type: 'regular'" and didn't see any interesting hits. The adapter returnr `regular_payroll` either from a hardcoded value or from the [enum](https://github.com/Finch-API/api-server/blob/master/lib/model.js#L117-L121).

Changing the return value of any of the adapters wouldn't be the right fix as that introduces a breaking change.