### PR TITLE
Update Providers page with legend and better formatting

### DIFF
--- a/docs/Development-Guides/Providers.md
+++ b/docs/Development-Guides/Providers.md
@@ -2,7 +2,35 @@
 
 The table below lays out the providers with the associated provider `id` that can be used in the `payroll_provider` parameter for Finch [Connect](../Product-Guides/Finch-Connect.md).
 
+<!-- theme: info -->
+> **Read:** The `Company`, `Directory`, `Individual`, `Employment`, `Payment` and `Pay Statement` endpoint are read-only endpoints. Providers can be either an API provider or an [Assisted Connect provider](../Product-Guides/Assisted-Connect-Flow.md).
 
+<!-- theme: info -->
+> **Benefits:** The benefits endpoints contain both read and write functionalities. Providers can be either an API benefit providers or an Assisted Benefit providers. Only `Create Benefit`, `Update Benefit`, `Enroll Individuals in Benefits` and `Unenroll Individuals from Benefits` endpoints are available for Assisted Benefits providers.
+
+### API Providers
+Display Name | Id | Read | Benefits
+---------|----------|----------|----------
+ADP Workforce Now | `adp_workforce_now` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+BambooHR | `bamboo_hr` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+bob | `bob` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Gusto | `gusto` | <span style="color:goldenrod">API</span> | <span style="color:goldenrod">API</span>
+Insperity | `insperity` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Justworks | `justworks` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Namely | `namely` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Paychex Flex | `paychex_flex` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Paycom | `paycom` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Paylocity | `paylocity` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+QuickBooks Payroll | `quickbooks` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Rippling | `rippling` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Run Powered by ADP | `adp_run` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Square Payroll | `square_payroll` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+TriNet | `trinet` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+UltiPro (UKG Pro) | `ulti_pro` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Workday | `workday` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+Zenefits | `zenefits` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
+
+### Assisted Providers
 Display Name | Id | Read | Benefits
 ---------|----------|----------|----------
 AAP iSolved | `aap_isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
@@ -12,7 +40,6 @@ Accupay iSolved | `accupay_isolved` | <span style="color:darkgreen">Assisted</sp
 Ace Workforce Technologies isolved | `ace_isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Adams Keegan | `adams_keegan` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 ADP TotalSource | `adp_totalsource` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-ADP Workforce Now | `adp_workforce_now` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Advantage Payroll Services | `advantage_payroll_services` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Affiliated HR Payroll Services iSolved | `affiliated_hr_payroll_services_isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Affiliated HR Payroll Services Evolution | `affiliated_hr_payroll_services_evolution` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
@@ -23,14 +50,12 @@ APS Payroll | `aps_payroll` | <span style="color:darkgreen">Assisted</span> | <s
 Asset HR | `asset_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Asure Software | `asure_software` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Balance Point | `balance_point` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-BambooHR | `bamboo_hr` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Baron Payroll iSolved | `baron_isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 BBCS Payroll | `bbcs` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 BBSI | `bbsi` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Bene-Care | `benecare` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Big Fish Employer Services | `big_fish_employer_services` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Bizchecks Payroll | `bizchecks_payroll` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-bob | `bob` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Ceridian Dayforce | `ceridian_dayforce` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Ceridian Powerpay | `ceridian_powerpay` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 CharlieHR | `charlie_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
@@ -54,18 +79,14 @@ G&A Partners | `gna_partners` | <span style="color:darkgreen">Assisted</span> | 
 Goco | `goco` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 GTM Payroll Services Evolution | `gtm_payroll_services_evolution` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 GTM Payroll Services iSolved | `gtm_payroll_services_isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Gusto | `gusto` | <span style="color:goldenrod">API</span> | <span style="color:goldenrod">API</span>
 Heartland | `heartland` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Highflyer HR | `highflyer_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Hubstaff | `hubstaff` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Humi | `humi` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 INFINITI HR | `infiniti_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Insperity | `insperity` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 iSolved | `isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Justworks | `justworks` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Keystone Payroll isolved | `keystone_isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 mp | `mp` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Namely | `namely` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 NaturalHR | `natural_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Newtek | `newtek` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Nextep | `nextep` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
@@ -75,12 +96,9 @@ OnPay | `onpay` | <span style="color:darkgreen">Assisted</span> | <span style="c
 Oracle PeopleSoft | `oracle_peoplesoft` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Paragon Payroll iSolved | `paragon_payroll_isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Patriot | `patriot` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Paychex Flex | `paychex_flex` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
-Paycom | `paycom` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Paycor | `paycor` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Payday Workforce Solutions | `payday_workforce_solutions` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 PayFit | `payfit` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Paylocity | `paylocity` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 PayNorthwest | `paynw` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 PayPro HCS isolved | `paypro_hcs_isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Payroll Network | `payroll_network` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
@@ -97,11 +115,8 @@ PrismHR | `prism_hr` | <span style="color:darkgreen">Assisted</span> | <span sty
 Proliant | `proliant` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 PropelHR | `propel_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Proxus HR isolved | `proxus_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-QuickBooks Payroll | `quickbooks` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Remote | `remote` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Rippling | `rippling` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 RMI PEO | `rmi_peo` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Run Powered by ADP | `adp_run` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Sage 50 Quantum Accounting | `sage_50_quantum_accounting` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Sage 50 US Edition Accounting | `sage_50_us_edition_accounting` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Sage Payroll | `sage_payroll` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
@@ -110,16 +125,13 @@ Sapling | `sapling` | <span style="color:darkgreen">Assisted</span> | <span styl
 Savant HCM Evolution | `savant_hcm_evolution` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Sequoia One | `sequoia_one` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Sheakley | `sheakley` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Square Payroll | `square_payroll` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Strategic Payroll Solutions isolved | `strategic_payroll_solutions_isolved` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 SuitePeople (Oracle NetSuite) | `suite_people` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 SurePayroll | `surepayroll` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 SyncHR | `sync_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 The Payroll Company | `the_payroll_company` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Toast Payroll | `toast_payroll` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-TriNet | `trinet` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 UKG Ready (Kronos) | `ukg_ready` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-UltiPro (UKG Pro) | `ulti_pro` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 VensureHR | `vensure_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Vfficient | `vfficient` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Viewpoint HR Management Spectrum | `viewpoint_hr_management_spectrum` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
@@ -128,10 +140,8 @@ Wagepoint | `wagepoint` | <span style="color:darkgreen">Assisted</span> | <span 
 Wave Payroll | `wave` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 WebHR | `web_hr` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 whirks | `whirks` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Workday | `workday` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Worklio | `worklio` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Workzoom | `workzoom` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 wurk | `wurk` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
 Xero | `xero` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>
-Zenefits | `zenefits` | <span style="color:goldenrod">API</span> | <span style="color:darkgreen">Assisted</span>
 Zoho Payroll | `zoho_payroll` | <span style="color:darkgreen">Assisted</span> | <span style="color:darkgreen">Assisted</span>

--- a/docs/Product-Guides/Assisted-Connect-Flow.md
+++ b/docs/Product-Guides/Assisted-Connect-Flow.md
@@ -1,6 +1,6 @@
 # Assisted Connect Flow
 
-Assisted Connect Flow (ACF) is our semi-automated product that expands coverage to 70+ providers. In contrast to our automated connections, the data for ACF providers is refreshed periodically. Our full list of coverage — for both API and ACF providers — can be found [here](https://tryfinch.notion.site/2484846e745343638e792ac0ff27481c?v=24efa5ea0cd44de89f3f8d3fbbf2ec6a).
+Assisted Connect Flow (ACF) is our semi-automated product that expands coverage to 70+ providers. In contrast to our automated connections, the data for ACF providers is refreshed periodically. Our full list of coverage — for both API and ACF providers — can be found [here](../Development-Guides/Providers.md).
 
 Contact our team at `developers@tryfinch.com` to get started or for more questions regarding pricing, missing providers, etc.
 


### PR DESCRIPTION
Based on feedback from customer meetings and [#3003](https://tryfinch.halp.com/tickets/3003).

- Added info for both Read + Benefits. Linked Assisted Connect doc to learn more
- Explained limitation of Assisted Benefits
- Separated providers between API vs Assisted
- Brought all API providers to the top for better readability and convenience. Thought is everyone uses API providers and most won't use Assisted