### PR TITLE
feat(benefitType): add new benefit type that have been used in api-server

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -1907,7 +1907,7 @@ components:
           nullable: true
         city:
           type: string
-          description: "\tCity, district, suburb, town, or village."
+          description: "City, district, suburb, town, or village."
           nullable: true
         state:
           type: string

--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -1998,7 +1998,6 @@ components:
         - s125_medical
         - s125_dental
         - s125_vision
-        - hsa
         - hsa_pre
         - hsa_post
         - fsa_medical

--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -1990,6 +1990,7 @@ components:
       enum:
         - 401k
         - 401k_roth
+        - 401k_loan
         - 403b
         - 403b_roth
         - '457'
@@ -1997,6 +1998,7 @@ components:
         - s125_medical
         - s125_dental
         - s125_vision
+        - hsa
         - hsa_pre
         - hsa_post
         - fsa_medical


### PR DESCRIPTION
## What
Add `401k_loan`  that have been used in api-server and fixed a bug for company city description
<img width="774" alt="Screen Shot 2022-04-29 at 11 02 53 AM" src="https://user-images.githubusercontent.com/34586832/165998726-34221d9a-45bd-4ceb-9f40-ff60add546b6.png">


## Why
- reflect on api doc to show developers what options of benefit/deduction type we will return

## Reference
- https://github.com/Finch-API/api-server/blob/master/adapters/insperity/utils.js#L273