### PR TITLE
feat: Document the `class_code` field as returned by the /employer/employment endpoint.

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -416,6 +416,7 @@ paths:
                           start_date: '2017-06-30'
                           end_date: null
                           is_active: true
+                          class_code: '8810'
                           location:
                             line1: 12 Bird Drive
                             line2: null
@@ -517,6 +518,10 @@ paths:
                             is_active:
                               type: boolean
                               description: '`true` if the individual an an active employee or contractor at the company.'
+                              nullable: true
+                            class_code:
+                              type: string
+                              description: "Worker's compensation'classification code for this employee"
                               nullable: true
                             location:
                               $ref: '#/components/schemas/Location'


### PR DESCRIPTION
Document the `class_code` field as returned by the /employer/employment endpoint.

I've been able to confirm this functionality in prod for:
* ADP Run ✅
* ADP WFN ✅
* Paycom ✅
* Gusto ✅
* Sandbox (WIP will add it to some of the individuals for `largeco`)
---------------------------------------
Won't do until requested by the developer:
* QBO (still in dev)
* Paychex (still in dev)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202482547603202