### PR TITLE
fix: no longer mention base64 in regards to the auth code for access token exchange

### DIFF
--- a/docs/3-Quickstart.md
+++ b/docs/3-Quickstart.md
@@ -69,7 +69,14 @@ title: Response
 ```
 <!-- type: tab-end -->
 
-Copy, paste, and run the command in your terminal. This `curl` command is going to make an HTTP POST request which will exchange our authorization header (our client_id and client_secret which is base64 encoded) and our newly generated authorization code for an access token.
+Copy, paste, and run the command in your terminal. This `curl` command is going to make an HTTP POST request with a JSON encoded request body containing your:
+
+- `client_id` (replace `<your_client_id>`),
+- `client_secret` (replace `<your_client_secret>`),
+- `redirect_uri`
+- and our newly generated authorization `code` (replace `<your_authorization_code>`)
+
+The response to this request will contain a JSON encoded object containing an `access_token` key, whose value will contain your newly created Finch access token (in this case `<your_access_token>`).
 
 In [OAuth2](https://oauth.net/2/) terms, the authorization `code` represents a user consenting your application access to their system. The `access_token` represents your application's access to your user's system.
 


### PR DESCRIPTION
The before text was talking about base64 encoding for HTTP Basic Auth despite the curl request no longer doing this. Replaced this with a block of text better explaining.