### PR TITLE
Update Pay Statement example with employee deduction type

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -710,6 +710,7 @@ paths:
                                   amount: 50000
                                   currency: usd
                                   pre_tax: true
+                                  type: 401k
                               employer_contributions:
                                 - name: Employee Medical Insurance
                                   amount: 23272


### PR DESCRIPTION
Example did not have a `type` field under `employee_deduction`, but the specification says that field should exist there.