### PR TITLE
Small grammar nitpick for Benefits API

### DIFF
--- a/docs/Product-Guides/Benefits-API.md
+++ b/docs/Product-Guides/Benefits-API.md
@@ -22,7 +22,7 @@ Before creating and enrolling employees in benefits, you must create an access t
 
 For a list of which providers are automated or assisted, please reference our [Providers](/docs/Development-Guides/Providers.md) guide.
 
-If you are using **Assisted** Benefits connections and you try to call the automated-only endpoints, you will receive a 501 error code `Not Implemented`. This is expected. The assisted flow does currently not support read endpoints. If you would like to learn more about how Assisted Connections work, you can view our [Assisted Connect Flow](/docs/Product-Guides/Assisted-Connect-Flow.md) product guide.
+If you are using **Assisted** Benefits connections and you try to call the automated-only endpoints, you will receive a 501 error code `Not Implemented`. This is expected. The assisted flow does not currently support read endpoints. If you would like to learn more about how Assisted Connections work, you can view our [Assisted Connect Flow](/docs/Product-Guides/Assisted-Connect-Flow.md) product guide.
 
 Example `Not Implemented` response:
 


### PR DESCRIPTION
Our Benefits API documentation had used both the phrase "currently not supported" and also the phrase "not currently supported". Based on the idea that customers would be looking for "is" or "is not" during questions about support, I recommend "not currently supported".