### PR TITLE
Add availability description to Benefits endpoints

### DIFF
--- a/docs/Product-Guides/Benefits-API.md
+++ b/docs/Product-Guides/Benefits-API.md
@@ -22,7 +22,7 @@ Before creating and enrolling employees in benefits, you must create an access t
 
 For a list of which providers are automated or assisted, please reference our [Providers](/docs/Development-Guides/Providers.md) guide.
 
-If you are using **Assisted** Benefits connections and you try to call the automated-only endpoints, you will receive a 501 error code `Not Implemented`. This is expected. The assisted flow does currently not support read endpoints. If you would like to learn more about how Assisted Connections work, you can view our [Assisted Connect Flow](/docs/Product-Guides/Assisted-Connect-Flow.md) product guide.
+If you are using **Assisted** Benefits connections and you try to call the automated-only endpoints, you will receive a 501 error code `Not Implemented`. This is expected. The assisted flow does not currently support read endpoints. If you would like to learn more about how Assisted Connections work, you can view our [Assisted Connect Flow](/docs/Product-Guides/Assisted-Connect-Flow.md) product guide.
 
 Example `Not Implemented` response:
 

--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -1038,7 +1038,10 @@ paths:
                       description: Example 401k
                       frequency: every_paycheck
       operationId: get-company-benefits
-      description: List all company-wide benefits.
+      description: |-
+        **Availability: Automated Benefits providers only**  
+          
+        List all company-wide benefits.
       parameters:
         - $ref: '#/components/parameters/API-Version'
     post:
@@ -1071,7 +1074,10 @@ paths:
                     name: unprocessable_request_error
                     finch_code: unsupported_paramters
                     message: Provider does not support benefit type '401k'
-      description: Creates a new company-wide benefit. Please use the `/meta` endpoint to view available types for each provider.
+      description: |-
+        **Availability: Automated and Assisted Benefits providers**  
+          
+        Creates a new company-wide benefit. Please use the `/meta` endpoint to view available types for each provider.
       requestBody:
         content:
           application/json:
@@ -1160,7 +1166,10 @@ paths:
                       frequencies:
                         - every_paycheck
       operationId: get-company-benefits-meta
-      description: Lists available types and configurations for the provider associated with the access token.
+      description: |-
+        **Availability: Automated and Assisted Benefits providers**  
+          
+        Lists available types and configurations for the provider associated with the access token.
       parameters:
         - $ref: '#/components/parameters/API-Version'
     parameters: []
@@ -1197,7 +1206,10 @@ paths:
                     finch_code: benefit_not_found
                     message: Benefit not found
       operationId: get-company-benefit
-      description: Lists benefit information for a given benefit
+      description: |-
+        **Availability: Automated Benefits providers only**  
+          
+        Lists benefit information for a given benefit
       parameters:
         - $ref: '#/components/parameters/API-Version'
     post:
@@ -1221,7 +1233,10 @@ paths:
           description: Bad Request
         '404':
           description: Benefit Not Found
-      description: Updates an existing company-wide benefit
+      description: |-
+        **Availability: Automated and Assisted Benefits providers**  
+          
+        Updates an existing company-wide benefit
       requestBody:
         content:
           application/json:
@@ -1281,7 +1296,10 @@ paths:
                     finch_code: benefit_not_found
                     message: Benefit not found
       operationId: get-company-benefits-enrolled
-      description: Lists individuals currently enrolled in a given benefit.
+      description: |-
+        **Availability: Automated Benefits providers only**  
+          
+        Lists individuals currently enrolled in a given benefit.
       parameters:
         - $ref: '#/components/parameters/API-Version'
     parameters:
@@ -1336,7 +1354,10 @@ paths:
                     finch_code: benefit_not_found
                     message: Benefit not found
       operationId: get-individual-benefits
-      description: Get enrolled benefit information for the given individuals.
+      description: |-
+        **Availability: Automated Benefits providers only**  
+          
+        Get enrolled benefit information for the given individuals.
       parameters:
         - $ref: '#/components/parameters/API-Version'
         - $ref: '#/components/parameters/Content-Type'
@@ -1473,6 +1494,8 @@ paths:
                     finch_code: unprocessable_parameters
                     message: HSA enrollment are not currently available for this provider
       description: |
+        **Availability: Automated and Assisted Benefits providers**  
+          
         Enroll an individual into a benefit. If the employee is already enrolled, the enrollment amounts will be adjusted.
 
         <!-- theme: warning -->
@@ -1618,7 +1641,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-      description: Unenroll individuals from a benefit
+      description: |-
+        **Availability: Automated and Assisted Benefits providers**  
+          
+        Unenroll individuals from a benefit
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Currently our Benefits endpoints do not specify whether they work for Automated or Assisted Benefits providers. While we do now have a separate documentation page specifying that Benefits endpoints should return errors if they are used incorrectly, it is important for the endpoint specifications themselves to say that they are or are not available for use depending on the type of provider.

This PR adds one of the following two strings to each Benefits endpoint as appropriate:
- "Availability: Automated and Assisted Benefits providers"
- "Availability: Automated providers only"