### PR TITLE
Add package.json to export openapi spec as library

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,10 @@
   "name": "@finch-api/api-spec",
   "version": "0.0.1",
   "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "files": [ "/reference/employer/openapi.yaml"],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/Finch-API/finch-docs.git"
+    "url": "git+https://github.com/Finch-API/finch-docs.git"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@finch-api/api-spec",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "files": [ "/reference/employer/openapi.yaml"],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/Finch-API/finch-docs.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/Finch-API/finch-docs/issues"
+  },
+  "publishConfig": {
+    "@finch-api::registry": "https://npm.pkg.github.com"
+  },
+  "homepage": "https://github.com/Finch-API/finch-docs#readme"
+}


### PR DESCRIPTION
### What

Add package.json to export openapi spec as library

### Why

We want to use our openapi spec as the source of truth for server side response validation. This allows us to build the api spec as an npm package for api server to use