### PR TITLE
Allow end_date to be null

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -533,6 +533,7 @@ paths:
                               $ref: '#/components/schemas/Date'
                             end_date:
                               $ref: '#/components/schemas/Date'
+                              nullable: true
                             is_active:
                               type: boolean
                               description: '`true` if the individual an an active employee or contractor at the company.'


### PR DESCRIPTION
## What
Change value of end_date in the employment endpoint to be potentially null

## Why
End dates can be null if the employee is active. 