### PR TITLE
Remove mentions of Slack and Halp from Integration Checklist

### DIFF
--- a/docs/Integrating-with-Finch/Integration Checklist.md
+++ b/docs/Integrating-with-Finch/Integration Checklist.md
@@ -84,5 +84,5 @@ Once you have tested your Finch integration with test accounts, you can go live.
 
 The following steps will ensure you and your team is set up for success once your Finch integration has gone live.
 
-- [ ]  We currently use Slack and Halp to keep track of support tickets. Ensure your team is on Slack and is comfortable with Halp.
-- [ ]  Learn how to use the developer dashboard to keep track of your connected customers and the health of each connection.
+- [ ]  We currently use Jira to keep track of support tickets. Ensure your team is able to access a Jira-based website.
+- [ ]  Learn how to use the Finch Developer Dashboard to keep track of your connected customers and the health of each connection.


### PR DESCRIPTION
The Integration Checklist previously listed Slack and Halp under the "Support" section. This has confused at least one customer who did not have a Slack channel. In addition, we no longer use Halp except as a connection between Slack and Jira.
Updated the "Support" section to only mention Jira.