### PR TITLE
Update Benefits curl command in Testing page

### DIFF
--- a/docs/Development-Guides/Testing.md
+++ b/docs/Development-Guides/Testing.md
@@ -48,7 +48,8 @@ curl https://api.tryfinch.com/employer/benefts \
 -H "Finch-API-Version: 2020-09-17" \
 -X "POST"
 -H "Content-Type: application/json" \
--d '{"type":"401k", "description": "Sample 401k", "frequency": \ "every_paycheck", "employee_deduction": {"type": "fixed",\ "amount": 100}, "company_contribution": {"type": "fixed", \ "amount": 100}}'
+-d '{"type":"401k", "description": \
+"Sample 401k", "frequency": "every_paycheck"}'
 ```
 **Response**
 ```json


### PR DESCRIPTION
Documentation for "Testing" previously had a curl command which used a JSON body containing a mix between creating a benefit and enrolling an individual. The corrected example is purely for creating a benefit.

Previous:
![Screenshot 2022-12-09 at 12 39 27](https://user-images.githubusercontent.com/8258251/206783856-4a2c2317-78e1-474a-8f02-e95da9f5fd71.png)

New:
![Screenshot 2022-12-09 at 12 38 52](https://user-images.githubusercontent.com/8258251/206783882-bada1401-7c5b-4204-8e02-3d9b50f3ef1e.png)
