### PR TITLE
Add ADP Workforce Now as Assisted connection

### DIFF
--- a/docs/Development-Guides/Providers.md
+++ b/docs/Development-Guides/Providers.md
@@ -50,8 +50,9 @@ Accupay iSolved | `accupay_isolved` | <span style="color:goldenrod">Assisted</sp
 Ace Workforce Technologies isolved | `ace_isolved` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 AccountantsWorld | `accountantsworld` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Adams Keegan | `adams_keegan` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-ADP Comprehensive Services | `adp_comprehensive` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+ADP Comprehensive Services | `adp_comprehensive` | <span style="color:goldenrod">Assisted*</span> | <span style="color:goldenrod">Assisted</span>
 ADP TotalSource | `adp_totalsource` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+ADP Workforce Now | `adp_workforce_now` | <span style="color:goldenrod">Assisted*</span> | <span style="color:goldenrod">Assisted</span>
 Advantage Payroll Services | `advantage_payroll_services` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Affiliated HR Payroll Services iSolved | `affiliated_hr_payroll_services_isolved` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Affiliated HR Payroll Services Evolution | `affiliated_hr_payroll_services_evolution` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>


### PR DESCRIPTION
- Add "ADP Workforce Now" to Assisted list
- Mark "ADP Comprehensive Services" as pay-enabled

Before:
![Screenshot 2022-12-22 at 10 57 03](https://user-images.githubusercontent.com/8258251/209196908-4faa3271-2bcd-4d7a-87cd-2455ac8aff41.png)

After:
![Screenshot 2022-12-22 at 10 56 20](https://user-images.githubusercontent.com/8258251/209196938-2e8a5f77-9128-40cc-85d1-0ff20ce0eac8.png)
