### PR TITLE
set security for providers endpoint to none as it doesn't require auth

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -1007,6 +1007,7 @@ paths:
       description: Return details on all available payroll and HR systems.
       parameters:
         - $ref: '#/components/parameters/API-Version'
+      security: []
   /introspect:
     get:
       summary: Introspect


### PR DESCRIPTION
A developer thought they would need an access token to access this in [SUPPORT-2377](https://tryfinch.atlassian.net/browse/SUPPORT-2377)