### PR TITLE
Add missing footnote in Compatibility doc

### DIFF
--- a/docs/Development-Guides/Compatibility.md
+++ b/docs/Development-Guides/Compatibility.md
@@ -32,7 +32,8 @@ title: HRIS
 ![individual.png](../../assets/images/individual.png)
 
 <p><i>* Initial only</i><br>
-<i>** No work email available</i></p>
+<i>** No work email available</i><br>
+<i>*** Contractors don't have these fields in the QBO system</i></p>
 
 ### Employment
 ![employment.png](../../assets/images/employment-2.png)


### PR DESCRIPTION
The Compatibility document is missing the footnote for a triple asterisk under the Individual endpoint's Quickbooks section. This update adds it to the text of the page.

Before:
![Screenshot 2023-02-07 at 09 28 07](https://user-images.githubusercontent.com/8258251/217304395-59809772-03b5-4084-a609-ae0971846227.png)

After:
![Screenshot 2023-02-07 at 09 27 39](https://user-images.githubusercontent.com/8258251/217304432-b58f7f7a-6f2b-4f3a-8a72-f06f2d74832c.png)
