### PR TITLE
add 502 error

### DIFF
--- a/docs/Development-Guides/Errors/Error-Types.md
+++ b/docs/Development-Guides/Errors/Error-Types.md
@@ -35,5 +35,5 @@ Name | Finch Code | Code | Description
 `rate_limit_exceeded_error` | `finch_rate_limit_exceeded` | 429 | The application has exceeded Finch's rate limits. Please retry later.
 `rate_limit_exceeded_error` | `upstream_rate_limit_exceeded` | 429 | The application has exceeded upstream provider rate limits. Please retry later.
 `server_error` | | 500 | The server experienced an unexpected error.
-`bad_gateway_error` | `upstream_provider_error` | 502 | The server experienced an unexpected error while interacting with an upstream service, such as a provider.
 `not_implemented_error` | | 501 | Finch does not support this specific endpoint for this specific provider.
+`bad_gateway_error` | `upstream_provider_error` | 502 | The server experienced an unexpected error while interacting with an upstream service, such as a provider.

--- a/docs/Development-Guides/Errors/Error-Types.md
+++ b/docs/Development-Guides/Errors/Error-Types.md
@@ -35,4 +35,5 @@ Name | Finch Code | Code | Description
 `rate_limit_exceeded_error` | `finch_rate_limit_exceeded` | 429 | The application has exceeded Finch's rate limits. Please retry later.
 `rate_limit_exceeded_error` | `upstream_rate_limit_exceeded` | 429 | The application has exceeded upstream provider rate limits. Please retry later.
 `server_error` | | 500 | The server experienced an unexpected error.
+`bad_gateway_error` | `upstream_provider_error` | 502 | The server experienced an unexpected error while interacting with an upstream service, such as a provider.
 `not_implemented_error` | | 501 | Finch does not support this specific endpoint for this specific provider.


### PR DESCRIPTION
for https://tryfinch.atlassian.net/browse/EN-822 adding documentation for the 502 error to indicate upstream provider issues