### PR TITLE
Remove response-times dead links

### DIFF
--- a/docs/Product-Guides/Automated-Connect-Flow.md
+++ b/docs/Product-Guides/Automated-Connect-Flow.md
@@ -56,7 +56,7 @@ focus: false
 
 ## Finch Connect in Your User's Onboarding
 
-If you are integrating Finch into your onboarding flow, we recommend taking the request latencies of the underlying employment systems into consideration while designing the onboarding flow.
+If you are integrating Finch into your onboarding flow, we recommend taking the request latencies of the underlying employment systems into consideration while designing the onboarding flow. You can read more about latencies [here](../Development-Guides/Data-Syncs.md)
 
 Based on the data points your application needs during onboarding, we recommend the following flows—
 

--- a/docs/Product-Guides/Automated-Connect-Flow.md
+++ b/docs/Product-Guides/Automated-Connect-Flow.md
@@ -5,6 +5,7 @@ Finch Connect is a front-end UI that allows your users to safely and securely gr
 <!--
 focus: false
 -->
+
 ![](../../assets/images/finchConnectIntro.png)
 
 ---
@@ -24,19 +25,23 @@ We recommend asking your user to connect when they are onboarding onto your appl
 ### How should I display Finch Connect?
 
 #### Default flow
-In the default flow, your user is shown an employment system selector page where they can choose which system they use. 
+
+In the default flow, your user is shown an employment system selector page where they can choose which system they use.
 
 <!--
 focus: false
 -->
+
 ![](../../assets/images/integratingConnect1B.png)
 
 #### Selector bypass flow
+
 If you already know which system your user uses or want to build your own selector page, you can bypass the selector page by using the `payroll_provider` option while opening Finch Connect.
 
 <!--
 focus: false
 -->
+
 ![](../../assets/images/integratingConnect2B2X.png)
 
 ### How do I incentivize my user to connect their system?
@@ -46,11 +51,12 @@ To improve conversion, it is important to set user expectations before opening F
 <!--
 focus: false
 -->
+
 ![](../../assets/images/improvingConnectConversion.png)
 
 ## Finch Connect in Your User's Onboarding
 
-If you are integrating Finch into your onboarding flow, we recommend taking the request latencies of the underlying employment systems into consideration while designing the onboarding flow. You can read more about latencies [here](../Development-Guides/Response-Times.md).
+If you are integrating Finch into your onboarding flow, we recommend taking the request latencies of the underlying employment systems into consideration while designing the onboarding flow.
 
 Based on the data points your application needs during onboarding, we recommend the following flows—
 

--- a/docs/Product-Guides/Automated-Connect-Flow.md
+++ b/docs/Product-Guides/Automated-Connect-Flow.md
@@ -56,7 +56,7 @@ focus: false
 
 ## Finch Connect in Your User's Onboarding
 
-If you are integrating Finch into your onboarding flow, we recommend taking the request latencies of the underlying employment systems into consideration while designing the onboarding flow. You can read more about latencies [here](../Development-Guides/Data-Syncs.md)
+If you are integrating Finch into your onboarding flow, we recommend taking the request latencies of the underlying employment systems into consideration while designing the onboarding flow. You can read more about latencies [here](../Development-Guides/Data-Syncs.md).
 
 Based on the data points your application needs during onboarding, we recommend the following flows—
 

--- a/toc.json
+++ b/toc.json
@@ -151,11 +151,6 @@
     },
     {
       "type": "item",
-      "title": "Response Times",
-      "uri": "docs/Development-Guides/Response-Times.md"
-    },
-    {
-      "type": "item",
       "title": "Compatibility",
       "uri": "docs/Development-Guides/Compatibility.md"
     },


### PR DESCRIPTION
I noticed a dead link in the docs referencing Response Times / Latency (see it on production [here](https://developer.tryfinch.com/docs/reference/a2c944f1041f6-automated-connect-flow#finch-connect-in-your-users-onboarding) under the section "Finch Connect in Your User's Onboarding") - it seems like there is no file corresponding to this link, so I went ahead and remove the reference to that and the uri in toc.json. 

Todo: 
- [x] confirm with product / engineering that this is safe to remove 