### PR TITLE
Fix typo

### DIFF
--- a/docs/Product-Guides/Benefits-API.md
+++ b/docs/Product-Guides/Benefits-API.md
@@ -4,7 +4,7 @@ Finch's [Benefits API](https://developer.tryfinch.com/docs/reference/b3A6MTg4Mzc
 
 ## Calling Finch’s API
 
-Before creating and enrolling employees in benefits, you must create an access token using our Finch Connect flow. If the provider is listed as an [Automated API Provider](https://developer.tryfinch.com/docs/reference/96f5be9e0ec1a-providers#automated-api-providers), you will the [Automated Connect Flow](https://developer.tryfinch.com/docs/reference/a2c944f1041f6-automated-connect-flow). If the provider is listed as an [Assisted API Provider](https://developer.tryfinch.com/docs/reference/96f5be9e0ec1a-providers#assisted-api-providers), you will use our [Assisted Connect Flow](https://developer.tryfinch.com/docs/reference/8c540ddeca222-assisted-connect-flow). Once you have an access token, you can call the Finch API normally.
+Before creating and enrolling employees in benefits, you must create an access token using our Finch Connect flow. If the provider is listed as an [Automated API Provider](https://developer.tryfinch.com/docs/reference/96f5be9e0ec1a-providers#automated-api-providers), you will use the [Automated Connect Flow](https://developer.tryfinch.com/docs/reference/a2c944f1041f6-automated-connect-flow). If the provider is listed as an [Assisted API Provider](https://developer.tryfinch.com/docs/reference/96f5be9e0ec1a-providers#assisted-api-providers), you will use our [Assisted Connect Flow](https://developer.tryfinch.com/docs/reference/8c540ddeca222-assisted-connect-flow). Once you have an access token, you can call the Finch API normally.
 
 1. Both **Automated** and **Assisted** Benefits connections can call these endpoints
     - `POST /employer/benefits` to create a new company-wide benefit or individual deduction


### PR DESCRIPTION
### What
Adding a missing word.

### Why
Sentence doesn't make sense without the missing word.

### What problem does this solve? Why are the changes the appropriate solution?
Fixes the typo. 

### Relevant Resources

### How has this been tested?
Before: "you will the [Automated Connect Flow](https://developer.tryfinch.com/docs/reference/a2c944f1041f6-automated-connect-flow)"
After: "you will **_use_** the [Automated Connect Flow](https://developer.tryfinch.com/docs/reference/a2c944f1041f6-automated-connect-flow)"
