### PR TITLE
employer/individual: communicate dob might be null

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -374,6 +374,7 @@ paths:
                               nullable: true
                             dob:
                               $ref: '#/components/schemas/Date'
+                              nullable: true
                             ssn:
                               type: string
                               description: 'Social Security number of the individual. This field is only available with the `ssn` scope enabled and the `options: { include: [''ssn''] }` param set in the body.'


### PR DESCRIPTION
fixed nullability on our schema for dob here : https://github.com/Finch-API/finch-openapi/pull/25 - figured it'd be worth updating our docs  - havent verified this looks ok on the render (we use `anyOf` in our schema so trying `nullable` here to see if it looks better),  just wanted to open a pr to get visibility 