### PR TITLE
Adds more padding between numbered elements that are currently scrunched

### DIFF
--- a/docs/Integrating-with-Finch/Integrate-Finch-Connect/Embed-Connect.md
+++ b/docs/Integrating-with-Finch/Integrate-Finch-Connect/Embed-Connect.md
@@ -29,6 +29,7 @@ Inside your code base folder, use the command line to install `react-finch-conne
 npm install --save react-finch-connect
 ```
 
+
 ### 2. Import the 'useFinchConnect' Hook
 
  ```javascript
@@ -82,6 +83,7 @@ const App = () => {
   );
 };
 ```
+
 
 ### 4. Receive the authorization code
 
@@ -155,6 +157,7 @@ The returned `FinchConnect` object exposes `open`, `close` and `destroy` lifecyc
 </html>
 ```
 
+
 ### 2. Initialize Finch Connect
 
 Inside a `<script>` inside the page `<body>`, initialize the FinchConnect object.
@@ -218,6 +221,7 @@ To open Finch Connect, use the `open` function returned by `FinchConnect` and ad
   </body>
 </html>
 ```
+
 
 ### 4. Exchange the authorization code
 


### PR DESCRIPTION
Adds padding to some elements on the embed finch connect guide, which are currently pretty scrunched. Example:
<img width="719" alt="Screenshot 2023-05-17 at 9 28 26 AM" src="https://github.com/Finch-API/finch-docs/assets/20044545/af7e3b7f-1a89-487c-82bc-017c69c4f21a">
