### PR TITLE
make it more explicit that “Finch-Data-Retrieved” time stamp applies …

### DIFF
--- a/docs/Development-Guides/Data-Syncs.md
+++ b/docs/Development-Guides/Data-Syncs.md
@@ -4,9 +4,9 @@ stoplight-id: f7af2039f9a7b
 
 # Data Syncs
 
-Finch syncs data with providers on a 24 hour cadence, and Finch API responses will return data from the most recent successful sync. Performing data syncs in this way ensures that latency for all Finch API requests should remain under 200ms.
+Finch syncs data with automated providers on a 24 hour cadence, and with assisted providers on a 7 day cadence; Finch API responses will return data from the most recent successful sync. Performing data syncs in this way ensures that latency for all Finch API requests should remain under 200ms.
 
-After an employer authorizes your application through Finch Connect, Finch will enqueue an initial data fetch job which will fetch all relevant data for the employer connection. If you attempt to request data before the initial sync has completed, Finch will request live data from the provider*. Live request latencies may range from several seconds to minutes for large batch sizes. Once the initial data sync has completed, Finch API responses will return the synced data.
+After an employer authorizes your application through Finch Connect, Finch will enqueue an initial data fetch job which will fetch all relevant data for the employer connection. For automated providers, if you attempt to request data before the initial sync has completed, Finch will request live data from the provider*. Live request latencies may range from several seconds to minutes for large batch sizes. Once the initial data sync has completed, Finch API responses will return the synced data.
 
 You can use several Finch response headers to determine the freshness of the data you receive:
 


### PR DESCRIPTION
make it more explicit that “Finch-Data-Retrieved” time stamp applies to automated AND assisted connections