### PR TITLE
Add 401(k) Loan to retirement benefits for benefit enroll endpoint

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -1633,7 +1633,7 @@ paths:
 
           **Retirement Benefits**
 
-          Includes 401(k), Roth 401(k), 403(b), Roth 403(b), 457, Roth 457, and Simple IRA
+          Includes 401(k), 401(k) Loan, Roth 401(k), 403(b), Roth 403(b), 457, Roth 457, and Simple IRA
 
           Field | Type | Description
           ------|------ | ----------


### PR DESCRIPTION
ForUsAll was asking why `catch_up` was required for 401k Loan if it wasn't listed as a retirement benefit. 

Phil confirmed in #service-operations that it should be. 

Thanks!