### PR TITLE
chore: Clarifies refresh rate limit of 1 req/hour/cxn

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -2161,7 +2161,7 @@ paths:
         - $ref: '#/components/parameters/API-Version'
         - $ref: '#/components/parameters/Content-Type'
       description: |-
-        Enqueue an automated job. Currently, only the `data-sync-all` job type is supported, which will enqueue a job to re-sync all data for a connection. `data-sync-all` has a concurrency limit of 1 job at a time per connection. This means that if this endpoint is called while a job is already in progress for this connection, Finch will return the `job_id` of the job that is currently in progress. Finch allows a fixed window rate limit of 1 forced refresh per hour.
+        Enqueue an automated job. Currently, only the `data-sync-all` job type is supported, which will enqueue a job to re-sync all data for a connection. `data-sync-all` has a concurrency limit of 1 job at a time per connection. This means that if this endpoint is called while a job is already in progress for this connection, Finch will return the `job_id` of the job that is currently in progress. Finch allows a fixed window rate limit of 1 forced refresh per hour per connection.
 
         This endpoint is available for *Scale* tier customers as an add-on. To request access to this endpoint, please contact your Finch account manager.
       requestBody:


### PR DESCRIPTION
### What

Clarifies that the rate limit on the refresh endpoint is 1 request per hour per connection


### Why

This has caused confusion for at least 1 customer (Pulley)