### PR TITLE
Notes about version timing

### DIFF
--- a/docs/Development-Guides/Versioning.md
+++ b/docs/Development-Guides/Versioning.md
@@ -11,7 +11,5 @@ We periodically release new, dated versions of the API whenever we make breaking
 
 Our current version is **2020-09-17**
 
-<!-- theme: info -->
-> As mentioned above we only increment the version for breaking changes, so this may be an older date. That doesn't mean API changes haven't occured, merely that they were backwards compatible. 
-
-The `Finch-API-Version` header must be set for every single request to our API.
+- We only increment the version for breaking changes, so this may be an older date. That doesn't mean API changes haven't occurred, merely that they were backward compatible.
+- The `Finch-API-Version` header must be set for every single request to our API.

--- a/docs/Development-Guides/Versioning.md
+++ b/docs/Development-Guides/Versioning.md
@@ -11,5 +11,5 @@ We periodically release new, dated versions of the API whenever we make breaking
 
 Our current version is **2020-09-17**
 
-- We only increment the version for breaking changes, so this may be an older date. That doesn't mean API changes haven't occurred, merely that they were backward compatible.
 - The `Finch-API-Version` header must be set for every single request to our API.
+- We only increment the version for breaking changes, so this may be an older date. That doesn't mean API changes haven't occurred, merely that they were backward compatible.

--- a/docs/Development-Guides/Versioning.md
+++ b/docs/Development-Guides/Versioning.md
@@ -11,4 +11,7 @@ We periodically release new, dated versions of the API whenever we make breaking
 
 Our current version is **2020-09-17**
 
+<!-- theme: info -->
+> As mentioned above we only increment the version for breaking changes, so this may be an older date. That doesn't mean API changes haven't occured, merely that they were backwards compatible. 
+
 The `Finch-API-Version` header must be set for every single request to our API.

--- a/docs/Integrating-with-Finch/Integrate-the-Finch-API.md
+++ b/docs/Integrating-with-Finch/Integrate-the-Finch-API.md
@@ -14,7 +14,7 @@ Every request to Finch's API requires the following headers—
 Header | Description
 ---------|----------
  `Authorization` | Bearer authorization header, which is formed by concatenating the word “Bearer” with the `access_token`, separated by a space.
- `Finch-API-Version` | Header used to specify the version for a given API request. Current version is 2020-09-17.
+ `Finch-API-Version` | Header used to specify the version for a given API request. Current version is 2020-09-17 (we only increment the [version](../Development-Guides/Versioning.md) for breaking changes).
 
 <!--
 type: tab


### PR DESCRIPTION
Adds a link to the version page on the integration page and adds a note about the date being old because we're good about not making breaking changes