### PR TITLE
update docs to show assisted benefits not supported for prismHR white-labels

### DIFF
--- a/.spectral.mjs
+++ b/.spectral.mjs
@@ -1,0 +1,2 @@
+import ruleset from "https://stoplight.io/api/v1/projects/cHJqOjE2NDA0MA/spectral.js?branch_slug=main&token=877ee350-e501-4073-9beb-b9a44ef0e85c";
+export default { extends: ruleset };

--- a/docs/Development-Guides/Providers.md
+++ b/docs/Development-Guides/Providers.md
@@ -1,6 +1,6 @@
 # Providers
 
-**Last Updated:** 2023-03-27
+**Last Updated:** 2023-07-13
 
 The table below lays out the providers with the associated provider `id` that can be used in the `payroll_provider` parameter for [Finch Connect](../Integrating-with-Finch/Integrate-Finch-Connect/Overview.md).
 

--- a/docs/Development-Guides/Providers.md
+++ b/docs/Development-Guides/Providers.md
@@ -36,7 +36,7 @@ Rippling | `rippling` | <span style="color:darkgreen">Automated</span> | <span >
 Run Powered by ADP | `adp_run` | <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted**</span>
 Sage HR | `sage_hr` | <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span>
 Sapling | `sapling` | <span style="color:darkgreen">Automated</span> | <span>Not Supported</span>
-Sequoia One | `sequoia_one` | <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span>
+Sequoia One | `sequoia_one` | <span style="color:darkgreen">Automated</span> | <span >Not Supported</span>
 Square Payroll | `square_payroll` | <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted**</span>
 TriNet | `trinet` | <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted**</span>
 UltiPro (UKG Pro) | `ulti_pro` | <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span>
@@ -62,7 +62,7 @@ Affiliated HR Payroll Services Evolution | `affiliated_hr_payroll_services_evolu
 Ahola | `ahola` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Alcott HR | `alcott_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 AlphaStaff | `alphastaff` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-Amplify HR | `amplify_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+Amplify HR | `amplify_hr` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Apdata | `apdata` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Apex | `apex` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 APS Payroll | `aps_payroll` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
@@ -79,7 +79,7 @@ Bene-Care | `benecare` | <span style="color:goldenrod">Assisted</span> | <span s
 Big Fish Employer Services | `big_fish_employer_services` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Bizchecks Payroll | `bizchecks_payroll` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Business Online Payroll | `business_online_payroll` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-C2 | `c2` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+C2 | `c2` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Ceridian Dayforce | `ceridian_dayforce` | <span style="color:goldenrod">Assisted*</span> | <span style="color:goldenrod">Assisted</span>
 Ceridian Powerpay | `ceridian_powerpay` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Cezanne HR | `cezannehr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
@@ -87,12 +87,12 @@ CharlieHR | `charlie_hr` | <span style="color:goldenrod">Assisted</span> | <span
 ClickUp | `clickup` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 CoAdvantage | `coadvantage` | <span style="color:goldenrod">Assisted*</span> | <span style="color:goldenrod">Assisted</span>
 Coastal Payroll | `coastal_payroll` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-CognosHR | `cognos_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+CognosHR | `cognos_hr` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Collage | `collage` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Commonwealth Payroll & HR | `commonwealth_payroll_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 ConnectPay | `connectpay` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted**</span>
 CPM Employer Services iSolved | `cpm_isolved` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-Creative Business Resources | `creative_business_resources` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+Creative Business Resources | `creative_business_resources` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Crescent Payroll Solutions | `crescent_payroll_solutions` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 CSC Paymaster | `csc_paymaster` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Darwinbox | `darwinbox` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
@@ -106,18 +106,18 @@ Doyle | `doyle_hcm` | <span style="color:goldenrod">Assisted</span> | <span styl
 Eddy | `eddyhr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Emplicity | `emplicity` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Employdrive | `employdrive` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-EmPower HR | `empower_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-Engage PEO | `engage_peo` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+EmPower HR | `empower_hr` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
+Engage PEO | `engage_peo` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Employer Flexible | `employer_flexible` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Employer Services Corporation (ESC) | `esc` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Everee | `everee` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Evolution Payroll Services | `evolution_payroll_services` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Excel Resources | `excel_resources` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-ExtensisHR | `extensis_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+ExtensisHR | `extensis_hr` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Flock | `flock` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Freshteam | `freshteam` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 FullStack PEO | `fullstack_peo` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-G&A Partners | `gna_partners` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+G&A Partners | `gna_partners` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Gig Wage | `gigwage` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Goco | `goco` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 greytHR | `greyt_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
@@ -134,7 +134,7 @@ HRO | `hro` | <span style="color:goldenrod">Assisted</span> | <span style="color
 HROne | `hrone` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Hubstaff | `hubstaff` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Humi | `humi` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-INFINITI HR | `infiniti_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+INFINITI HR | `infiniti_hr` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Infor | `infor` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Iris HR | `iris_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 iSolved | `isolved` | <span style="color:goldenrod">Assisted*</span> | <span style="color:goldenrod">Assisted</span>
@@ -177,7 +177,7 @@ PeopleForce | `peopleforce` | <span style="color:goldenrod">Assisted</span> | <s
 PeopleHum | `peoplehum` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 People Lease | `people_lease` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Platinum Group | `platinum_group` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-PrestigePEO | `prestige_peo` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+PrestigePEO | `prestige_peo` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 PrimePay | `primepay` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 PrismHR | `prism_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Proliant | `proliant` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
@@ -186,7 +186,7 @@ ProSoftware | `prosoftware` | <span style="color:goldenrod">Assisted</span> | <s
 Proxus HR isolved | `proxus_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Quality Payroll and Benefits | `quality_payroll_benefits` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Remote | `remote` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-Resourcing Edge | `resourcing_edge` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+Resourcing Edge | `resourcing_edge` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 RMI PEO | `rmi_peo` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Sage Payroll | `sage_payroll` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 SAP SuccessFactors | `successfactors` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
@@ -210,9 +210,9 @@ Trakstar | `trakstar` | <span style="color:goldenrod">Assisted</span> | <span st
 UKG Ready (Kronos) | `ukg_ready` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Uzio | `uzio` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Velocity Global | `velocity_global` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-VensureHR | `vensure_hr` | <span style="color:goldenrod">Assisted*  </span> | <span style="color:goldenrod">Assisted</span>
+VensureHR | `vensure_hr` | <span style="color:goldenrod">Assisted*  </span> | <span >Not Supported</span>
 Venture Workforce | `venture_workforce` | <span style="color:goldenrod">Assisted*</span> | <span style="color:goldenrod">Assisted</span>
-Vfficient | `vfficient` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+Vfficient | `vfficient` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Viewpoint HR Management Spectrum | `viewpoint_hr_management_spectrum` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Viewpoint HR Management Vista | `viewpoint_hr_management_vista` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Viventium | `viventium` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
@@ -224,7 +224,7 @@ Worklio | `worklio` | <span style="color:goldenrod">Assisted</span> | <span styl
 Workplace HCM | `workplace_hcm` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Workzoom | `workzoom` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 wurk | `wurk` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
-Xenium HR | `xenium_hr` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
+Xenium HR | `xenium_hr` | <span style="color:goldenrod">Assisted</span> | <span >Not Supported</span>
 Xero | `xero` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 Zoho Payroll | `zoho_payroll` | <span style="color:goldenrod">Assisted</span> | <span style="color:goldenrod">Assisted</span>
 


### PR DESCRIPTION
What changed:

- Update docs to show Benefits are not supported for PrismHR white labels (list below) 
- Confirmed through various sources that, since PrismHR is a PEO, they completely own making changes to employee deductions. Finch would not be able to process assisted benefits requests

[Sequoia One](https://seq.prismhr.com/seq/auth/#/login?lang=en)

[Amplify HR](https://whr.prismhr.com/whr.amp/)

[C2](https://c2p.prismhr.com/)

[Creative Business Resources (CBR)](https://cbr.prismhr.com/cbr/?) 

[Cognos HR](https://cog.prismhr.com/cog/)

[Empower HR](https://epw.prismhr.com/epw/?)

[Engage PEO](https://manager.engagepeo.com/phr/dbweb.asp?dbcgm=1)

[Extensis HR](https://exg.prismhr.com/exg/)

[G&A Partners](https://gna.prismhr.com/gna/?)

[Infiniti HR](https://inf.prismhr.com/inf.hsg/?)

[Prestige PEO](https://pea.prismhr.com/pea/?)

[Resourcing Edge](https://vso.prismhr.com/vso/?)

[Vensure HR / Vfficient](https://vns.prismhr.com/vns/?/)

[Xenium HR](https://prism.xeniumhr.com/xen/)