### PR TITLE
add SDK documentation

### DIFF
--- a/docs/Development-Guides/SDKs.md
+++ b/docs/Development-Guides/SDKs.md
@@ -1,0 +1,17 @@
+---
+stoplight-id: 1nu9t8ipeuh7p
+---
+
+# SDKs
+
+### Backend SDKs
+Finch has SDKs in several popular languages to make it easy to integrate with Finch APIs. These SDKs are regularly updated for breaking and non-breaking API changes, and are generated from our [OpenAPI](https://github.com/Finch-API/finch-openapi) file.
+
+* [Node](https://github.com/Finch-API/finch-api-node)
+* [Python](https://github.com/Finch-API/finch-api-python)
+* [Java](https://github.com/Finch-API/finch-api-java)
+
+If you do not see your language here, reach out to us!
+
+### Frontend SDKs
+

--- a/docs/Development-Guides/SDKs.md
+++ b/docs/Development-Guides/SDKs.md
@@ -5,7 +5,7 @@ stoplight-id: 1nu9t8ipeuh7p
 # SDKs
 
 ### Backend SDKs
-Finch maintains SDKs in several popular languages to make it easy to integrate with Finch APIs. These SDKs are regularly updated for breaking and non-breaking API changes. In addition to the installation and quickstart information, each repository contains an `api.md` which documents available methods and data models.
+Finch maintains SDKs in several popular languages to make it easy to integrate with Finch APIs. These SDKs are regularly updated for breaking and non-breaking API changes. In addition to installation and quickstart information, each repository contains an `api.md` which documents available methods and data models.
 
 * [Node](https://github.com/Finch-API/finch-api-node)
 * [Python](https://github.com/Finch-API/finch-api-python)

--- a/docs/Development-Guides/SDKs.md
+++ b/docs/Development-Guides/SDKs.md
@@ -16,5 +16,6 @@ If you do not see your language here, reach out to us!
 ### Frontend SDKs
 
 Finch's frontend SDKs allow you to [embed Finch Connect](Embed-Connect.md) into your application, enabling you to provide a seamless integration experience for your users. Take a look at our repositories below:
+
 * [Javascript](https://github.com/Finch-API/finch-connect-js)
 * [React](https://github.com/Finch-API/react-connect)

--- a/docs/Development-Guides/SDKs.md
+++ b/docs/Development-Guides/SDKs.md
@@ -5,7 +5,7 @@ stoplight-id: 1nu9t8ipeuh7p
 # SDKs
 
 ### Backend SDKs
-Finch has SDKs in several popular languages to make it easy to integrate with Finch APIs. These SDKs are regularly updated for breaking and non-breaking API changes, and are generated from our [OpenAPI](https://github.com/Finch-API/finch-openapi) file.
+Finch maintains SDKs in several popular languages to make it easy to integrate with Finch APIs. These SDKs are regularly updated for breaking and non-breaking API changes, and are generated from our [OpenAPI](https://github.com/Finch-API/finch-openapi) schema. In addition to the quickstart, each repository contains an `api.md` which documents available methods and data models.
 
 * [Node](https://github.com/Finch-API/finch-api-node)
 * [Python](https://github.com/Finch-API/finch-api-python)
@@ -15,3 +15,6 @@ If you do not see your language here, reach out to us!
 
 ### Frontend SDKs
 
+Finch's frontend SDKs allow you to [embed Finch Connect](Embed-Connect.md) into your application,enabling you to provide a seamless integration experience for your users. Take a look at our repositories below:
+* [Javascript](https://github.com/Finch-API/finch-connect-js)
+* [React](https://github.com/Finch-API/react-connect)

--- a/docs/Development-Guides/SDKs.md
+++ b/docs/Development-Guides/SDKs.md
@@ -5,7 +5,7 @@ stoplight-id: 1nu9t8ipeuh7p
 # SDKs
 
 ### Backend SDKs
-Finch maintains SDKs in several popular languages to make it easy to integrate with Finch APIs. These SDKs are regularly updated for breaking and non-breaking API changes, and are generated from our [OpenAPI](https://github.com/Finch-API/finch-openapi) schema. In addition to the installation and quickstart information, each repository contains an `api.md` which documents available methods and data models.
+Finch maintains SDKs in several popular languages to make it easy to integrate with Finch APIs. These SDKs are regularly updated for breaking and non-breaking API changes. In addition to the installation and quickstart information, each repository contains an `api.md` which documents available methods and data models.
 
 * [Node](https://github.com/Finch-API/finch-api-node)
 * [Python](https://github.com/Finch-API/finch-api-python)

--- a/docs/Development-Guides/SDKs.md
+++ b/docs/Development-Guides/SDKs.md
@@ -5,7 +5,7 @@ stoplight-id: 1nu9t8ipeuh7p
 # SDKs
 
 ### Backend SDKs
-Finch maintains SDKs in several popular languages to make it easy to integrate with Finch APIs. These SDKs are regularly updated for breaking and non-breaking API changes, and are generated from our [OpenAPI](https://github.com/Finch-API/finch-openapi) schema. In addition to the quickstart, each repository contains an `api.md` which documents available methods and data models.
+Finch maintains SDKs in several popular languages to make it easy to integrate with Finch APIs. These SDKs are regularly updated for breaking and non-breaking API changes, and are generated from our [OpenAPI](https://github.com/Finch-API/finch-openapi) schema. In addition to the installation and quickstart information, each repository contains an `api.md` which documents available methods and data models.
 
 * [Node](https://github.com/Finch-API/finch-api-node)
 * [Python](https://github.com/Finch-API/finch-api-python)
@@ -15,6 +15,6 @@ If you do not see your language here, reach out to us!
 
 ### Frontend SDKs
 
-Finch's frontend SDKs allow you to [embed Finch Connect](Embed-Connect.md) into your application,enabling you to provide a seamless integration experience for your users. Take a look at our repositories below:
+Finch's frontend SDKs allow you to [embed Finch Connect](Embed-Connect.md) into your application, enabling you to provide a seamless integration experience for your users. Take a look at our repositories below:
 * [Javascript](https://github.com/Finch-API/finch-connect-js)
 * [React](https://github.com/Finch-API/react-connect)

--- a/toc.json
+++ b/toc.json
@@ -146,6 +146,11 @@
       "uri": "docs/Development-Guides/Data-Syncs.md"
     },
     {
+       "type": "item",
+      "title": "SDKs",
+      "uri": "docs/Development-Guides/SDKs.md"
+    },
+    {
       "type": "divider",
       "title": "Best Practices"
     },


### PR DESCRIPTION
Add page for SDKs. Pending SDK testing

Inspiration:
https://stripe.com/docs/libraries
https://plaid.com/docs/api/libraries/
https://docs.merge.dev/sdk/
https://workos.com/docs/sdks