### PR TITLE
Modified openapi annual contribution limit nullable

### DIFF
--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -511,7 +511,7 @@ paths:
                           custom_fields:
                             - name: tShirtSize
                               value: L
-                          source_id: "000001"
+                          source_id: '000001'
               schema:
                 type: object
                 properties:
@@ -1582,7 +1582,7 @@ paths:
           `company_contribution.amount`| `integer` | Contribution amount in cents (if `fixed`) or basis points
           `catch_up`| `boolean` | Whether to enable catch up for this individual.
           `annual_maximum`| `integer` (`nullable`) | The annual maximum in cents for this individual.
-          `annual_contribution_limit` | `string` | `individual` or `family`
+          `annual_contribution_limit` | `string` (`nullable`) | `individual` or `family`
           `effective_date` | `string` (`nullable`) | The date which the benefit should take effect by. **This field is currently only available for assisted benefits.**
 
           ***

--- a/reference/employer/openapi.yaml
+++ b/reference/employer/openapi.yaml
@@ -1566,9 +1566,9 @@ paths:
           `employee_deduction.amount`| `integer` | Deduction amount in cents (if `fixed`) or basis points (if `percent`)
           `company_contribution.type` | `string` | Contribution Type (`fixed` or `percent`)
           `company_contribution.amount`| `integer` | Contribution amount in cents (if `fixed`) or basis points
-          `catch_up`| `boolean` | Whether to enable catch up for this individual.
-          `annual_maximum`| `integer` (`nullable`)| The annual maximum in cents for this individual.
-          `effective_date` | `string` (`nullable`) | The date which the benefit should take effect by. **This field is currently only available for assisted benefits.**
+          `catch_up`| `boolean` | Whether to enable catch up for this individual
+          `annual_maximum`| `integer` (`nullable`)| The annual maximum in cents for this individual
+          `effective_date` | `string` (`nullable`) | The date which the benefit should take effect by (`mm/dd/yyyy`) **This field is currently only available for assisted benefits.**
 
           ***
 
@@ -1580,10 +1580,10 @@ paths:
           `employee_deduction.amount`| `integer` | Deduction amount in cents (if `fixed`) or basis points (if `percent`)
           `company_contribution.type` | `string` | Contribution Type (`fixed` or `percent`)
           `company_contribution.amount`| `integer` | Contribution amount in cents (if `fixed`) or basis points
-          `catch_up`| `boolean` | Whether to enable catch up for this individual.
-          `annual_maximum`| `integer` (`nullable`) | The annual maximum in cents for this individual.
-          `annual_contribution_limit` | `string` (`nullable`) | `individual` or `family`
-          `effective_date` | `string` (`nullable`) | The date which the benefit should take effect by. **This field is currently only available for assisted benefits.**
+          `catch_up`| `boolean` | Whether to enable catch up for this individual
+          `annual_maximum`| `integer` (`nullable`) | The annual maximum in cents for this individual
+          `annual_contribution_limit` | `string` (`nullable`) | Whether HSA is applied towards `individual` or `family`
+          `effective_date` | `string` (`nullable`) | The date which the benefit should take effect by (`mm/dd/yyyy`) **This field is currently only available for assisted benefits.**
 
           ***
 
@@ -1595,7 +1595,7 @@ paths:
           `employee_deduction.amount`| `integer` | Deduction amount in cents (if `fixed`) or basis points (if `percent`)
           `company_contribution.type` | `string` | Contribution Type (`fixed` or `percent`)
           `company_contribution.amount`| `integer` | Contribution amount in cents (if `fixed`) or basis points
-          `effective_date` | `string` (`nullable`) | The date which the benefit should take effect by. **This field is currently only available for assisted benefits.**
+          `effective_date` | `string` (`nullable`) | The date which the benefit should take effect by (`mm/dd/yyyy`) **This field is currently only available for assisted benefits.**
       parameters:
         - $ref: '#/components/parameters/API-Version'
         - $ref: '#/components/parameters/Content-Type'


### PR DESCRIPTION
Updated /enroll docs to make the `annual_contribution_limit` field nullable. Also updates some formatting