### PR TITLE
DEVOP-412: update s3 logos bucket

### DIFF
--- a/reference/management/openapi.yaml
+++ b/reference/management/openapi.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.0
-info: 
+info:
   title: Management API Reference
   version: '2020-09-17'
   contact: {}
@@ -67,8 +67,8 @@ paths:
                       products:
                         - company
                         - directory
-                      icon: 'https://finch-logos.s3.us-west-2.amazonaws.com/gustoIcon.png'
-                      logo: 'https://finch-logos.s3.us-west-2.amazonaws.com/gustoLogo.png'
+                      icon: 'https://finch-assets.s3.us-west-2.amazonaws.com/provider-logos/gustoIcon.png'
+                      logo: 'https://finch-assets.s3.us-west-2.amazonaws.com/provider-logos/gustoLogo.png'
                       mfa_required: true
                       primary_color: '#f45d47'
                       authentication_methods:


### PR DESCRIPTION
### What

Substitute any mentions of the finch-logos bucket and replace with finch-assets/provider-logos

### Why

The finch-logos bucket is in the legacy-production environment and is being migrated (as part of a larger S3 migration) to the new environments:
- production - bucket finch-assets
- staging - bucket finch-stg-assets

### Other Information

- Jira ticket [DEVOP-412](https://tryfinch.atlassian.net/browse/DEVOP-412)