### PR TITLE
update paycor payment integration to automated

### DIFF
--- a/docs/Development-Guides/Providers.md
+++ b/docs/Development-Guides/Providers.md
@@ -27,7 +27,7 @@ Finch’s most popular providers and supported products.
 | Namely | `namely` |  <span style="color:darkgreen">Automated</span> | Upon Request | Upon Request |
 | Paychex Flex | `paychex_flex` |  <span style="color:darkgreen">Automated</span> |  <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span> |
 | Paycom | `paycom` |  <span style="color:darkgreen">Automated</span> |  <span style="color:darkgreen">Automated</span> | Upon Request |
-| Paycor | `paycor` |  <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span> | Upon Request |
+| Paycor | `paycor` |  <span style="color:darkgreen">Automated</span> | <span style="color:darkgreen">Automated</span> | Upon Request |
 | Paylocity | `paylocity` |  <span style="color:darkgreen">Automated</span> |  <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span> |
 | Personio | `personio` |  <span style="color:darkgreen">Automated</span> | N/A | N/A |
 | QuickBooks Payroll | `quickbooks` |  <span style="color:darkgreen">Automated</span> |  <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span> |

--- a/docs/Development-Guides/Providers.md
+++ b/docs/Development-Guides/Providers.md
@@ -27,7 +27,7 @@ Finch’s most popular providers and supported products.
 | Namely | `namely` |  <span style="color:darkgreen">Automated</span> | Upon Request | Upon Request |
 | Paychex Flex | `paychex_flex` |  <span style="color:darkgreen">Automated</span> |  <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span> |
 | Paycom | `paycom` |  <span style="color:darkgreen">Automated</span> |  <span style="color:darkgreen">Automated</span> | Upon Request |
-| Paycor | `paycor` |  <span style="color:darkgreen">Automated</span> | <span style="color:darkgreen">Automated</span> | Upon Request |
+| Paycor | `paycor` |  <span style="color:darkgreen">Automated</span> | <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span> |
 | Paylocity | `paylocity` |  <span style="color:darkgreen">Automated</span> |  <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span> |
 | Personio | `personio` |  <span style="color:darkgreen">Automated</span> | N/A | N/A |
 | QuickBooks Payroll | `quickbooks` |  <span style="color:darkgreen">Automated</span> |  <span style="color:darkgreen">Automated</span> | <span style="color:goldenrod">Assisted</span> |


### PR DESCRIPTION
Per [this thread ](https://tryfinch.slack.com/archives/C01J2523N6R/p1696524623803279) Paycor is now "Paycor is now automated for org +pay and only assisted for benefits", this PR updates the docs to match that.