### PR TITLE
fix: Remove null from department compatibility matrix

### DIFF
--- a/reference/management/openapi.yaml
+++ b/reference/management/openapi.yaml
@@ -1108,7 +1108,6 @@ components:
               type: boolean
             department:
               type: boolean
-              nullable: true
             manager:
               type: object
               properties:


### PR DESCRIPTION
### What
Remove null from department compatibility matrix

### Why
The compatibility matrix fields should be a `boolean`. 