### PR TITLE
feat: Add client type and connection type to `/introspect`

### DIFF
--- a/reference/management/openapi.yaml
+++ b/reference/management/openapi.yaml
@@ -964,7 +964,10 @@ components:
       enum:
         - provider
         - finch
-      description: the type of connection associated with a token. provider = connection to an external provider, finch = finch generated data
+      description: |-
+        The type of the connection associated with the token.<br>
+        `provider` - connection to an external provider<br>
+        `finch` - finch-generated data.
       x-tags:
         - Models
     BenefitFeaturesAndOperations:

--- a/reference/management/openapi.yaml
+++ b/reference/management/openapi.yaml
@@ -257,6 +257,10 @@ paths:
                   client_id:
                     type: string
                     description: The client id of the application associated with the `access_token`.
+                  client_type:
+                    $ref: '#/components/schemas/ClientType'
+                  connection_type:
+                    $ref: '#/components/schemas/ConnectionType'
                   company_id:
                     type: string
                     description: The Finch uuid of the company associated with the `access_token`.
@@ -329,7 +333,9 @@ paths:
                   value:
                     account_id: d8ef1814-5913-492f-b5c0-a16e2d6432c9
                     client_id: 25ea8bd8-f76b-41f9-96e3-1e6162021c50
+                    client_type: production
                     company_id: 87eb4bc3-f76b-35e7-78d2-8f7822021d73
+                    connection_type: provider
                     products:
                       - company
                       - directory
@@ -942,6 +948,25 @@ components:
             enum:
               - individual
               - family
+    ClientType:
+      type: string
+      title: ClientType
+      enum:
+        - production
+        - development
+        - sandbox
+      description: the type of application associated with a token
+      x-tags:
+        - Models
+    ConnectionType:
+      type: string
+      title: ConnectionType
+      enum:
+        - provider
+        - finch
+      description: the type of connection associated with a token. provider = connection to an external provider, finch = finch generated data
+      x-tags:
+        - Models
     BenefitFeaturesAndOperations:
       type: object
       nullable: true

--- a/reference/management/openapi.yaml
+++ b/reference/management/openapi.yaml
@@ -955,7 +955,7 @@ components:
         - production
         - development
         - sandbox
-      description: the type of application associated with a token
+      description: The type of application associated with a token.
       x-tags:
         - Models
     ConnectionType:


### PR DESCRIPTION
### What
- Add client type and connection type to openAPI spec

### Why
`"client_type": "production" | "development" | "sandbox"`: the type of application associated with this token. equivalent to application.status
`"connection_type": "provider" | "finch"`: the type of connection associated with this token. `provider` = external, `finch` = finch generated
