### PR TITLE
Rename employer_deductions to employer_contributions on the provider endpoint

### DIFF
--- a/reference/management/openapi.yaml
+++ b/reference/management/openapi.yaml
@@ -226,7 +226,7 @@ paths:
                               type: true
                               pre_tax: true
                               currency: true
-                            employer_deductions:
+                            employer_contributions:
                               name: true
                               amount: true
                               currency: true
@@ -1818,7 +1818,7 @@ components:
                   type: boolean
                 currency:
                   type: boolean
-            employer_deductions:
+            employer_contributions:
               type: object
               properties:
                 name:


### PR DESCRIPTION
Renames `employer_deductions` to `employer_contributions`

See https://github.com/Finch-API/api-server/pull/9141 for details